### PR TITLE
fix: correct Recieved→Received typo in error message

### DIFF
--- a/eval/scripts/consolidate_gcp.bash
+++ b/eval/scripts/consolidate_gcp.bash
@@ -14,7 +14,7 @@ gcp_link=$1
 
 # if doesnt start with gcp, then its a local path
 if [[ $gcp_link != gs* ]]; then
-    echo "Not a gs link. Recieved: $gcp_link"
+    echo "Not a gs link. Received: $gcp_link"
     exit 1
 fi
 


### PR DESCRIPTION
Fix typo in error message in `eval/scripts/consolidate_gcp.bash`: `Recieved` → `Received`.

**Change:**
- Line 17: `echo "Not a gs link. Recieved: "` → `echo "Not a gs link. Received: "`

**Why:**
User-visible error message when an invalid GCP link is provided.

---
*Submitted via PR攻关 automation*